### PR TITLE
Implement 10‑digit code routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+
+### Restaurant Codes
+
+Each restaurant can be accessed via a unique 10‑digit code appended to the domain. For example:
+
+```
+https://scanogskip.dk/1234567890
+```
+
+The example above opens the Ockabasi menu. You can define additional codes in `pages/[code].js`.

--- a/pages/[code].js
+++ b/pages/[code].js
@@ -1,0 +1,22 @@
+import Ockabasi from "./ockabasi";
+import Custom404 from "./pages/404";
+
+const codeMap = {
+  "1234567890": Ockabasi,
+};
+
+export default function CodePage({ code }) {
+  const Component = codeMap[code];
+  if (Component) {
+    return <Component />;
+  }
+  return <Custom404 />;
+}
+
+export async function getServerSideProps({ params }) {
+  const { code } = params;
+  if (!/^[0-9]{10}$/.test(code)) {
+    return { notFound: true };
+  }
+  return { props: { code } };
+}


### PR DESCRIPTION
## Summary
- create `[code].js` dynamic route to render pages by code
- document restaurant codes in README

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68554b859438832084d9ff1185ebc7af